### PR TITLE
support custom port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 Live reloading for GitBook
 ==========================
+
+Insert livereload script for the gitbook website.
+
+Add it to your `book.json` with livereload port default to 35729:
+
+```js
+{
+    "plugins": ["livereload"]
+}
+```
+
+or use a custom port:
+
+```js
+{
+    "plugins": ["livereload"],
+    "pluginsConfig": {
+        "livereload": {
+            "port": 35800
+        }
+    }
+}
+```

--- a/book/plugin.js
+++ b/book/plugin.js
@@ -1,11 +1,13 @@
-(function() {
-  var newEl = document.createElement('script'),
-      firstScriptTag = document.getElementsByTagName('script')[0];
+require(["gitbook"], function(gitbook) {
+  gitbook.events.bind("start", function(e, config) {
+    var newEl = document.createElement('script'),
+        firstScriptTag = document.getElementsByTagName('script')[0],
+        port = config.livereload.port || 35729;
 
-  if (firstScriptTag) {
-    newEl.async = 1;
-    newEl.src = '//' + window.location.hostname + ':35729/livereload.js';
-    firstScriptTag.parentNode.insertBefore(newEl, firstScriptTag);
-  }
-
-})();
+    if (firstScriptTag) {
+      newEl.async = 1;
+      newEl.src = '//' + window.location.hostname + ':' + port + '/livereload.js';
+      firstScriptTag.parentNode.insertBefore(newEl, firstScriptTag);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitbook-plugin-livereload",
     "description": "Live reloading for your gitbook",
     "main": "index.js",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "engines": {
         "gitbook": "*"
     },


### PR DESCRIPTION
this commit make livereload port configurable.

currently gitbook support [configurable lrport](https://github.com/GitbookIO/gitbook/blob/master/lib/index.js#L106), it changes tinylr server's port, but it is just the first half of the feature. The second half, e.g. the front-end livereload script tag, is created by this plugin, so if this plugin can also support configurable port, the feature will become complete.

This feature will make writing multiple books simultaneously more pleasant.
